### PR TITLE
Fix DomainMappings when internal-encryption is enabled

### DIFF
--- a/pkg/reconciler/contour/contour.go
+++ b/pkg/reconciler/contour/contour.go
@@ -189,7 +189,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 		for _, port := range svc.Spec.Ports {
 
 			if port.Name == networking.ServicePortNameH2C {
-				if cfg.Network != nil && cfg.Network.InternalEncryption {
+				if cfg.Network != nil && cfg.Network.InternalEncryption && port.Port != networking.ServiceHTTPPort {
 					serviceToProtocol[name] = resources.InternalEncryptionH2Protocol
 					logger.Debugf("marked an http2 svc %s as h2 for internal encryption", name)
 				} else {

--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -188,17 +188,7 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 				svc.RequestHeadersPolicy = postSplitHeaders
 
 				if proto, ok := serviceToProtocol[split.ServiceName]; ok {
-					//In order for domain mappings to work with internal
-					//encryption, need to unencrypt traffic back to the envoy.
-					//See
-					//https://github.com/knative-sandbox/net-contour/issues/862
-					//Can identify domain mappings by the presence of the
-					//RewriteHost field on the Path
-					if path.RewriteHost != "" {
-						svc.Protocol = ptr.String("h2c")
-					} else {
-						svc.Protocol = ptr.String(proto)
-					}
+					svc.Protocol = ptr.String(proto)
 				}
 
 				if cfg.Network != nil && cfg.Network.InternalEncryption {


### PR DESCRIPTION
# Changes

- :bug: Fix bug
- Set proto to h2c when ports named http2 use port 80, even when internal encryption is on. 
- the previous fix in #860 expected the K-Original-Host header to be present in the appendheaders section. However, it turns out that isn't added to the endpoint probe. This means that the ep would use h2 on port 80 when it was for DomainMappings.
- Instead of adding the k-original-host header to the endpoint probes, or only checking for the rewriteHost field, I think the solution I'm proposing in the PR is simpler, and gets at the root of the problem: traffic to port 80 shouldn't try to be encrypted.
- See this discussion for more context: https://github.com/knative-sandbox/net-contour/pull/860#discussion_r1099192228

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #862 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Fixes issue where DomainMappings do not become ready when Internal Encryption is enabled.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
