### PR TITLE
use new encryption flags from https://github.com/knative/networking/pull/858

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	k8s.io/apimachinery v0.27.1
 	k8s.io/client-go v0.26.5
 	knative.dev/hack v0.0.0-20230926181829-f2f9b6f91263
-	knative.dev/networking v0.0.0-20230926123909-c382f81bd011
+	knative.dev/networking v0.0.0-20231002132535-463dc388389e
 	knative.dev/pkg v0.0.0-20230926133247-0f52db700d63
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -705,8 +705,8 @@ k8s.io/utils v0.0.0-20230209194617-a36077c30491 h1:r0BAOLElQnnFhE/ApUsg3iHdVYYPB
 k8s.io/utils v0.0.0-20230209194617-a36077c30491/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 knative.dev/hack v0.0.0-20230926181829-f2f9b6f91263 h1:e6r9J1YopzSh6tDCpyKhVBfRUlZ2r0KRo9wupRjdRF4=
 knative.dev/hack v0.0.0-20230926181829-f2f9b6f91263/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
-knative.dev/networking v0.0.0-20230926123909-c382f81bd011 h1:FUbAMo0hVK49wJcUTEJfyMQhPCOwoKBEpphCeHrpAiE=
-knative.dev/networking v0.0.0-20230926123909-c382f81bd011/go.mod h1:q3caOSuP1eAzp6Aef8iPcbjnoufxxopv3yeOPOB1yrc=
+knative.dev/networking v0.0.0-20231002132535-463dc388389e h1:IifOH0ZKyU+QtY97+GUoopC+vyFMlee6cOw+wxK7cxc=
+knative.dev/networking v0.0.0-20231002132535-463dc388389e/go.mod h1:U9yqeTf2NtTY5aexYLbE4LAoIt/FAsnoERbnejJKlgI=
 knative.dev/pkg v0.0.0-20230926133247-0f52db700d63 h1:L0O5LRuKFkdwuR+MrDLGjrXgaQv9+7xse+kC7EboshI=
 knative.dev/pkg v0.0.0-20230926133247-0f52db700d63/go.mod h1:NzXHwtuwTWXyMD1KbL2ONwLk8cLROLYTtujCTTG7xQs=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/pkg/reconciler/contour/contour.go
+++ b/pkg/reconciler/contour/contour.go
@@ -40,7 +40,6 @@ import (
 	"knative.dev/net-contour/pkg/reconciler/contour/resources/names"
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
-	netcfg "knative.dev/networking/pkg/config"
 	"knative.dev/networking/pkg/status"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
@@ -190,14 +189,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 		for _, port := range svc.Spec.Ports {
 
 			if port.Name == networking.ServicePortNameH2C {
-				if cfg.Network != nil && (cfg.Network.DataplaneTrust != netcfg.TrustDisabled) {
+				if cfg.Network != nil && cfg.Network.SystemInternalTLSEnabled() {
 					serviceToProtocol[name] = resources.InternalEncryptionH2Protocol
 					logger.Debugf("marked an http2 svc %s as h2 for internal encryption", name)
 				} else {
 					serviceToProtocol[name] = "h2c"
 				}
 				break
-			} else if cfg.Network != nil && (cfg.Network.DataplaneTrust != netcfg.TrustDisabled) {
+			} else if cfg.Network != nil && cfg.Network.SystemInternalTLSEnabled() {
 				serviceToProtocol[name] = resources.InternalEncryptionProtocol
 				logger.Debugf("marked a svc %s as tls for internal encryption", name)
 				break

--- a/pkg/reconciler/contour/contour_test.go
+++ b/pkg/reconciler/contour/contour_test.go
@@ -723,7 +723,7 @@ var (
 		Network: &netconfig.Config{
 			// Right now, any trust configuration which is not Disabled should be equivalent to what we used to have as "internal-encryption=enabled"
 			// TODO: Expand test coverage when more trust states are implemented
-			DataplaneTrust: netconfig.TrustMinimal,
+			SystemInternalTLS: netconfig.EncryptionEnabled,
 		},
 	}
 )

--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -207,7 +207,7 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 					}
 				}
 
-				if cfg.Network != nil && (cfg.Network.DataplaneTrust != netcfg.TrustDisabled) {
+				if cfg.Network != nil && cfg.Network.SystemInternalTLSEnabled() {
 					svc.UpstreamValidation = &v1.UpstreamValidation{
 						CACertificate: fmt.Sprintf("%s/%s", system.Namespace(), netcfg.ServingRoutingCertName),
 						SubjectName:   certificates.LegacyFakeDnsName,

--- a/pkg/reconciler/contour/resources/httpproxy_test.go
+++ b/pkg/reconciler/contour/resources/httpproxy_test.go
@@ -2367,7 +2367,7 @@ func TestMakeProxiesInternalEncryption(t *testing.T) {
 				Network: &netcfg.Config{
 					// Right now, any trust configuration which is not Disabled should be equivalent to what we used to have as "internal-encryption=enabled"
 					// TODO: Expand test coverage when more trust states are implemented
-					DataplaneTrust: netcfg.TrustMinimal,
+					SystemInternalTLS: netcfg.EncryptionEnabled,
 				},
 			}
 

--- a/vendor/knative.dev/networking/config/config-network.yaml
+++ b/vendor/knative.dev/networking/config/config-network.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: networking
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "cfad3b9a"
+    knative.dev/example-checksum: "b2698fe8"
 data:
   _example: |
     ################################
@@ -73,7 +73,7 @@ data:
     #   namespace-wildcard-cert-selector: {}
     #
     # Useful labels include the "kubernetes.io/metadata.name" label to
-    # avoid provisioning a certifcate for the "kube-system" namespaces.
+    # avoid provisioning a certificate for the "kube-system" namespaces.
     # Use the following selector to match pre-1.0 behavior of using
     # "networking.knative.dev/disableWildcardCert" to exclude namespaces:
     #
@@ -114,16 +114,45 @@ data:
     # domain-template above to determine the full URL for the tag.
     tag-template: "{{.Tag}}-{{.Name}}"
 
-    # Controls whether TLS certificates are automatically provisioned and
-    # installed in the Knative ingress to terminate external TLS connection.
-    # 1. Enabled: enabling auto-TLS feature.
-    # 2. Disabled: disabling auto-TLS feature.
+    # auto-tls is deprecated and replaced by external-domain-tls
     auto-tls: "Disabled"
+
+    # Controls whether TLS certificates are automatically provisioned and
+    # installed in the Knative ingress to terminate TLS connections
+    # for cluster external domains (like: app.example.com)
+    # - Enabled: enables the TLS certificate provisioning feature for cluster external domains.
+    # - Disabled: disables the TLS certificate provisioning feature for cluster external domains.
+    external-domain-tls: "Disabled"
+
+    # Controls weather TLS certificates are automatically provisioned and
+    # installed in the Knative ingress to terminate TLS connections
+    # for cluster local domains (like: app.namespace.svc.cluster.local)
+    # - Enabled: enables the TLS certificate provisioning feature for cluster cluster-local domains.
+    # - Disabled: disables the TLS certificate provisioning feature for cluster cluster local domains.
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    cluster-local-domain-tls: "Disabled"
+
+    # internal-encryption is deprecated and replaced by system-internal-tls
+    internal-encryption: "false"
+
+    # system-internal-tls controls weather TLS encryption is used for connections between
+    # the internal components of Knative:
+    # - ingress to activator
+    # - ingress to queue-proxy
+    # - activator to queue-proxy
+    #
+    # Possible values for this flag are:
+    # - Enabled: enables the TLS certificate provisioning feature for cluster cluster-local domains.
+    # - Disabled: disables the TLS certificate provisioning feature for cluster cluster local domains.
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    system-internal-tls: "Disabled"
 
     # Controls the behavior of the HTTP endpoint for the Knative ingress.
     # It requires auto-tls to be enabled.
-    # 1. Enabled: The Knative ingress will be able to serve HTTP connection.
-    # 2. Redirected: The Knative ingress will send a 301 redirect for all
+    # - Enabled: The Knative ingress will be able to serve HTTP connection.
+    # - Redirected: The Knative ingress will send a 301 redirect for all
     # http connections, asking the clients to use HTTPS.
     #
     # "Disabled" option is deprecated.
@@ -172,35 +201,3 @@ data:
     # fronting Knative with an external loadbalancer that deals with TLS termination and
     # Knative doesn't know about that otherwise.
     default-external-scheme: "http"
-
-    # internal-encryption is deprecated and replaced by dataplane-trust and controlplane-trust
-    # internal-encryption indicates whether internal traffic is encrypted or not.
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
-    #       for now. Use with caution.
-    internal-encryption: "false"
-
-    # dataplane-trust indicates the level of trust established in the knative data-plane.
-    # dataplane-trust = "disabled" (the default) - uses no encryption for internal data plane traffic
-    # Using any other value ensures that the following traffic is encrypted using TLS:
-    #  - ingress to activator
-    #  - ingress to queue-proxy
-    #  - activator to queue-proxy
-    #
-    # dataplane-trust = "minimal" ensures data messages are encrypted, Kingress authenticate that the receiver is a Ksvc
-    # dataplane-trust = "enabled" same as "minimal" and in addition, Kingress authenticate that Ksvc is at the correct namespace
-    # dataplane-trust = "mutual" same as "enabled" and in addition, Ksvc authenticate that the messages come from the Kingress
-    # dataplane-trust = "identity" same as "mutual" with Kingress adding a trusted sender identity to the message
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing for now. Use with caution.
-    dataplane-trust: "disabled"
-
-    # controlplane-trust indicates the level of trust established in the knative control-plane.
-    # controlplane-trust = "disabled" (the default) - uses no encryption for internal control plane traffic
-    # Using any other value ensures that control traffic is encrypted using TLS.
-    #
-    # controlplane-trust = "enabled" ensures control messages are encrypted using TLS (client authenticate the server)
-    # controlplane-trust = "mutual" ensures control messages are encrypted using mTLS (client and server authenticate each other)
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing for now. Use with caution.
-    controlplane-trust: "disabled"

--- a/vendor/knative.dev/networking/pkg/apis/networking/metadata_validation.go
+++ b/vendor/knative.dev/networking/pkg/apis/networking/metadata_validation.go
@@ -29,6 +29,7 @@ var (
 		IngressClassAnnotationKey,
 		CertificateClassAnnotationKey,
 		DisableAutoTLSAnnotationKey,
+		DisableExternalDomainTLSAnnotationKey,
 		HTTPOptionAnnotationKey,
 
 		IngressClassAnnotationAltKey,

--- a/vendor/knative.dev/networking/pkg/apis/networking/register.go
+++ b/vendor/knative.dev/networking/pkg/apis/networking/register.go
@@ -70,10 +70,16 @@ const (
 
 	// DisableAutoTLSAnnotationKey is the annotation key attached to a Knative Service/DomainMapping
 	// to indicate that AutoTLS should not be enabled for it.
+	// Deprecated: use DisableExternalDomainTLSAnnotationKey instead.
 	DisableAutoTLSAnnotationKey = PublicGroupName + "/disableAutoTLS"
 
 	// DisableAutoTLSAnnotationAltKey is an alternative casing to DisableAutoTLSAnnotationKey
+	// Deprecated: use DisableExternalDomainTLSAnnotationKey instead.
 	DisableAutoTLSAnnotationAltKey = PublicGroupName + "/disable-auto-tls"
+
+	// DisableExternalDomainTLSAnnotationKey is the annotation key attached to a Knative Service/DomainMapping
+	// to indicate that external-domain-tls should not be enabled for it.
+	DisableExternalDomainTLSAnnotationKey = PublicGroupName + "/disable-external-domain-tls"
 
 	// HTTPOptionAnnotationKey is the annotation key attached to a Knative Service/DomainMapping
 	// to indicate the HTTP option of it.
@@ -130,9 +136,15 @@ var (
 		CertificateClassAnnotationAltKey,
 	}
 
-	DisableAutoTLSAnnotation = kmap.KeyPriority{
+	// Deprecated: use DisableExternalDomainTLSAnnotation instead.
+	DisableAutoTLSAnnotation = DisableExternalDomainTLSAnnotation
+
+	DisableExternalDomainTLSAnnotation = kmap.KeyPriority{
+		// backward compatibility
 		DisableAutoTLSAnnotationKey,
 		DisableAutoTLSAnnotationAltKey,
+
+		DisableExternalDomainTLSAnnotationKey,
 	}
 
 	HTTPProtocolAnnotation = kmap.KeyPriority{
@@ -153,6 +165,9 @@ func GetHTTPProtocol(annotations map[string]string) (val string) {
 	return HTTPProtocolAnnotation.Value(annotations)
 }
 
-func GetDisableAutoTLS(annotations map[string]string) (val string) {
-	return DisableAutoTLSAnnotation.Value(annotations)
+// Deprecated: use GetDisableExternalDomainTLS instead.
+var GetDisableAutoTLS = GetDisableExternalDomainTLS
+
+func GetDisableExternalDomainTLS(annotations map[string]string) (val string) {
+	return DisableExternalDomainTLSAnnotation.Value(annotations)
 }

--- a/vendor/knative.dev/networking/pkg/certificates/constants.go
+++ b/vendor/knative.dev/networking/pkg/certificates/constants.go
@@ -20,41 +20,39 @@ import "strings"
 
 const (
 	Organization = "knative.dev"
-	//nolint:all
-	LegacyFakeDnsName = "data-plane." + Organization
-	//nolint:all
-	// Deprecated: FakeDnsName is deprecated. Please use the DataPlaneRoutingName or DataPlaneUserName function.
-	FakeDnsName            = LegacyFakeDnsName
-	dataPlaneUserPrefix    = "kn-user-"
-	dataPlaneRoutingPrefix = "kn-routing-"
-	ControlPlaneName       = "kn-control"
 
-	//These keys are meant to line up with cert-manager, see
-	//https://cert-manager.io/docs/usage/certificate/#additional-certificate-output-formats
+	// nolint:all
+	LegacyFakeDnsName = "data-plane." + Organization
+
+	// nolint:all
+	// Deprecated: FakeDnsName is deprecated.
+	// Please use the DataPlaneRoutingSAN for calls to the Activator
+	// and the DataPlaneUserSAN function for calls to a Knative-Service via Queue-Proxy.
+	FakeDnsName = LegacyFakeDnsName
+
+	dataPlaneUserPrefix = "kn-user-"
+	DataPlaneRoutingSAN = "kn-routing"
+
+	// These keys are meant to line up with cert-manager, see
+	// https://cert-manager.io/docs/usage/certificate/#additional-certificate-output-formats
 	CaCertName     = "ca.crt"
 	CertName       = "tls.crt"
 	PrivateKeyName = "tls.key"
 
-	//These should be able to be deprecated some time in the future when the new names are fully adopted
+	// These should be able to be deprecated some time in the future when the new names are fully adopted
 	// #nosec
+	// Deprecated: please use CaCertName instead.
 	SecretCaCertKey = "ca-cert.pem"
 	// #nosec
+	// Deprecated: please use CertName instead.
 	SecretCertKey = "public-cert.pem"
 	// #nosec
+	// Deprecated: please use PrivateKeyName instead.
 	SecretPKKey = "private-key.pem"
 )
 
-// DataPlaneRoutingName constructs a san for a data-plane-routing certificate
-// Accepts a routingId  - a unique identifier used as part of the san (default is "0" used when an empty routingId is provided)
-func DataPlaneRoutingName(routingID string) string {
-	if routingID == "" {
-		routingID = "0"
-	}
-	return dataPlaneRoutingPrefix + strings.ToLower(routingID)
-}
-
-// DataPlaneUserName constructs a san for a data-plane-user certificate
-// Accepts a namespace  - the namespace for which the certificate was created
-func DataPlaneUserName(namespace string) string {
+// DataPlaneUserSAN constructs a SAN for a data-plane-user certificate in the
+// target namespace of a Knative Service.
+func DataPlaneUserSAN(namespace string) string {
 	return dataPlaneUserPrefix + strings.ToLower(namespace)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -892,7 +892,7 @@ k8s.io/utils/trace
 # knative.dev/hack v0.0.0-20230926181829-f2f9b6f91263
 ## explicit; go 1.18
 knative.dev/hack
-# knative.dev/networking v0.0.0-20230926123909-c382f81bd011
+# knative.dev/networking v0.0.0-20231002132535-463dc388389e
 ## explicit; go 1.18
 knative.dev/networking/config
 knative.dev/networking/pkg


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- In response to: https://github.com/knative/networking/pull/858
- Uses new function to identify if internal tls is enabled.
- Removes references to Dataplane trust

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
