### PR TITLE
fix: Bump Go and Kind Versions

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.25.x
         - v1.26.x
         - v1.27.x
+        - v1.28.x
 
     env:
       KO_DOCKER_REPO: registry.local:5000/knative # registry setup by setup-kind
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Go 1.19.x
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
+        go-version: 1.21.x
 
     - uses: imjasonh/setup-ko@v0.6
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ replace (
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/projectcontour/contour v1.25.0
-	go.uber.org/zap v1.26.0
+	go.uber.org/zap v1.25.0
 	k8s.io/api v0.26.5
 	k8s.io/apimachinery v0.27.1
 	k8s.io/client-go v0.26.5

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ replace (
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/projectcontour/contour v1.25.0
-	go.uber.org/zap v1.25.0
+	go.uber.org/zap v1.26.0
 	k8s.io/api v0.26.5
 	k8s.io/apimachinery v0.27.1
 	k8s.io/client-go v0.26.5


### PR DESCRIPTION
Kind version change to test version v1.26 to v.1.28
Go version is bumped to v1.21
#961 