### PR TITLE
Filter IngressTLS for visibility IngressVisibilityExternalIP

### DIFF
--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -103,8 +103,9 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 	ing = ing.DeepCopy()
 	ingress.InsertProbe(ing)
 
-	hostToTLS := make(map[string]v1alpha1.IngressTLS, len(ing.Spec.TLS))
-	for _, tls := range ing.Spec.TLS {
+	externalIngressTLS := ing.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP)
+	hostToTLS := make(map[string]v1alpha1.IngressTLS, len(externalIngressTLS))
+	for _, tls := range externalIngressTLS {
 		for _, host := range tls.Hosts {
 			hostToTLS[host] = tls
 		}

--- a/pkg/reconciler/contour/resources/kingress.go
+++ b/pkg/reconciler/contour/resources/kingress.go
@@ -135,12 +135,13 @@ func MakeEndpointProbeIngress(ctx context.Context, ing *v1alpha1.Ingress, previo
 		}
 	}
 
-	hasCert := len(ing.Spec.TLS) > 0 || config.FromContext(ctx).Contour.DefaultTLSSecret != nil
+	externalIngressTLS := ing.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP)
+	hasCert := len(externalIngressTLS) > 0 || config.FromContext(ctx).Contour.DefaultTLSSecret != nil
 
 	if ing.Spec.HTTPOption == v1alpha1.HTTPOptionRedirected && hasCert {
 		// Set the probe to operate over HTTPS IFF we have certificates AND are TLS-required
 		childIng.Spec.HTTPOption = v1alpha1.HTTPOptionRedirected
-		childIng.Spec.TLS = append(childIng.Spec.TLS, ing.Spec.TLS...)
+		childIng.Spec.TLS = append(childIng.Spec.TLS, externalIngressTLS...)
 		for i := range childIng.Spec.TLS {
 			childIng.Spec.TLS[i].Hosts = probeHosts
 		}

--- a/pkg/reconciler/contour/resources/kingress_test.go
+++ b/pkg/reconciler/contour/resources/kingress_test.go
@@ -273,7 +273,8 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 			Spec: v1alpha1.IngressSpec{
 				HTTPOption: v1alpha1.HTTPOptionRedirected,
 				Rules: []v1alpha1.IngressRule{{
-					Hosts: []string{"example.com"},
+					Hosts:      []string{"example.com"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
 					HTTP: &v1alpha1.HTTPIngressRuleValue{
 						Paths: []v1alpha1.HTTPIngressPath{{
 							Splits: []v1alpha1.IngressBackendSplit{{
@@ -310,7 +311,8 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 			Spec: v1alpha1.IngressSpec{
 				HTTPOption: v1alpha1.HTTPOptionRedirected,
 				Rules: []v1alpha1.IngressRule{{
-					Hosts: []string{"goo.gen-0.bar.foo.net-contour.invalid"},
+					Hosts:      []string{"goo.gen-0.bar.foo.net-contour.invalid"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
 					HTTP: &v1alpha1.HTTPIngressRuleValue{
 						Paths: []v1alpha1.HTTPIngressPath{{
 							Splits: []v1alpha1.IngressBackendSplit{{


### PR DESCRIPTION
Although net-contour does not (yet) support `cluster-local-domain-tls`, enabling the feature will create additional entries in `IngressTLS`. As net-contour currently only expects entries for `IngressVisibilityExternalIP` visibilities, this PR filters them out to keep the existing behaviour.

# Changes
- Filter IngressTLS for visibility IngressVisibilityExternalIP

Partially https://github.com/knative/serving/issues/14624

/assign @dprotaso 
/assign @KauzClay 
