### PR TITLE
Bump cluster version to 1.28 in e2e scripts

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -18,7 +18,7 @@ source $(dirname $0)/e2e-common.sh
 
 
 # Script entry point.
-initialize $@
+initialize --cluster-version=1.28 $@
 
 test_flags="-timeout=60m"
 if (( KIND )); then


### PR DESCRIPTION
# Changes
- specify k8s v1.28 as a flag in e2e tests

Fixes #1043 
