### PR TITLE
Set CORS policy values only for when HTTPProxy associated with external visibility

### DIFF
--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -305,7 +305,7 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 					Fqdn: host,
 				}
 
-				if cfg.Contour.CORSPolicy != nil {
+				if cfg.Contour.CORSPolicy != nil && rule.Visibility == v1alpha1.IngressVisibilityExternalIP {
 					hostProxy.Spec.VirtualHost.CORSPolicy = cfg.Contour.CORSPolicy
 				}
 

--- a/pkg/reconciler/contour/resources/httpproxy_test.go
+++ b/pkg/reconciler/contour/resources/httpproxy_test.go
@@ -2575,7 +2575,7 @@ func TestMakeProxiesCORSPolicy(t *testing.T) {
 			},
 		}},
 	}, {
-		name: "set corsPolicy values for cluster local visibility",
+		name: "do not set corsPolicy values for cluster local visibility",
 		ing: &v1alpha1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
@@ -2628,26 +2628,6 @@ func TestMakeProxiesCORSPolicy(t *testing.T) {
 			Spec: v1.HTTPProxySpec{
 				VirtualHost: &v1.VirtualHost{
 					Fqdn: "bar.foo",
-					CORSPolicy: &v1.CORSPolicy{
-						AllowCredentials: true,
-						AllowOrigin: []string{
-							"*",
-						},
-						AllowMethods: []v1.CORSHeaderValue{
-							"GET",
-							"POST",
-							"OPTIONS",
-						},
-						AllowHeaders: []v1.CORSHeaderValue{
-							"authorization",
-							"cache-control",
-						},
-						ExposeHeaders: []v1.CORSHeaderValue{
-							"Content-Length",
-							"Content-Range",
-						},
-						MaxAge: "10m",
-					},
 				},
 				Routes: []v1.Route{{
 					EnableWebsockets: true,
@@ -2730,26 +2710,6 @@ func TestMakeProxiesCORSPolicy(t *testing.T) {
 			Spec: v1.HTTPProxySpec{
 				VirtualHost: &v1.VirtualHost{
 					Fqdn: "bar.foo.svc",
-					CORSPolicy: &v1.CORSPolicy{
-						AllowCredentials: true,
-						AllowOrigin: []string{
-							"*",
-						},
-						AllowMethods: []v1.CORSHeaderValue{
-							"GET",
-							"POST",
-							"OPTIONS",
-						},
-						AllowHeaders: []v1.CORSHeaderValue{
-							"authorization",
-							"cache-control",
-						},
-						ExposeHeaders: []v1.CORSHeaderValue{
-							"Content-Length",
-							"Content-Range",
-						},
-						MaxAge: "10m",
-					},
 				},
 				Routes: []v1.Route{{
 					EnableWebsockets: true,
@@ -2832,26 +2792,6 @@ func TestMakeProxiesCORSPolicy(t *testing.T) {
 			Spec: v1.HTTPProxySpec{
 				VirtualHost: &v1.VirtualHost{
 					Fqdn: "bar.foo.svc.cluster.local",
-					CORSPolicy: &v1.CORSPolicy{
-						AllowCredentials: true,
-						AllowOrigin: []string{
-							"*",
-						},
-						AllowMethods: []v1.CORSHeaderValue{
-							"GET",
-							"POST",
-							"OPTIONS",
-						},
-						AllowHeaders: []v1.CORSHeaderValue{
-							"authorization",
-							"cache-control",
-						},
-						ExposeHeaders: []v1.CORSHeaderValue{
-							"Content-Length",
-							"Content-Range",
-						},
-						MaxAge: "10m",
-					},
 				},
 				Routes: []v1.Route{{
 					EnableWebsockets: true,


### PR DESCRIPTION
# Changes

- :broom: Currently, when setting CORS policy in config-contour, all HTTPProxies are modified to include the CORS settings.
This PR modifies the code to set CORS policy values only for when HTTPProxy is associated with external visibility.
- add test to confirm CORS policy settings are not included in HTTPProxy resources with cluster local visibility.

/kind cleanup

