### PR TITLE
Fix nil pointer dereference error when parsing config map

### DIFF
--- a/pkg/reconciler/contour/config/contour.go
+++ b/pkg/reconciler/contour/config/contour.go
@@ -81,7 +81,7 @@ func NewContourFromConfigMap(configMap *corev1.ConfigMap) (*Contour, error) {
 			return nil, err
 		}
 
-		if len(contourCORSPolicy.AllowOrigin) == 0 || len(contourCORSPolicy.AllowMethods) == 0 {
+		if contourCORSPolicy == nil || len(contourCORSPolicy.AllowOrigin) == 0 || len(contourCORSPolicy.AllowMethods) == 0 {
 			return nil, fmt.Errorf("the following fields are required but are missing or empty: %s.allowOrigin and %s.allowMethods", corsPolicy, corsPolicy)
 		}
 

--- a/pkg/reconciler/contour/config/contour_test.go
+++ b/pkg/reconciler/contour/config/contour_test.go
@@ -175,6 +175,18 @@ maxAge: "10m"
 			},
 		},
 	}, {
+		name:    "empty configuration",
+		wantErr: true,
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      ContourConfigName,
+			},
+			Data: map[string]string{
+				corsPolicy: "",
+			},
+		},
+	}, {
 		name:    "wrong option",
 		wantErr: true,
 		config: &corev1.ConfigMap{


### PR DESCRIPTION
# Changes

- :bug: Fix nil pointer dereference error when parsing the cors-policy field config-contour config map

PS: Error found while investigating issues in serving tests:
* https://github.com/knative/serving/pull/15204
* https://github.com/knative/serving/pull/15231

/kind bug

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Resolved a nil pointer exception triggered by the cors-policy field being set to an empty value.
```